### PR TITLE
remove extra container

### DIFF
--- a/src/Main.jsx
+++ b/src/Main.jsx
@@ -51,8 +51,6 @@ const Main = (props) => {
                 }
             </div>
           </div>
-        </div>
-        <div className="container">
           <div className="columns">
             <div className="column">
               <div className="box has-text-centered">


### PR DESCRIPTION
Page layout has an extra container class. This removes the extra container and fixes a minor visual glitch in the vertical spacing between the rows.