### PR TITLE
Better meta tags

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,14 +8,31 @@
   <link rel="stylesheet" href="%PUBLIC_URL%/bulma.min.css">
   <meta name="theme-color" content="#000000" />
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-  <meta name="description" content="Dai statistics live from the Ethereum blockchain." />
+
+  <title>Dai Stats</title>
+  <meta name="description" content="Dai statistics live from the Ethereum blockchain.">
+
+  <!-- Google / Search Engine Tags -->
+  <meta itemprop="name" content="Dai Stats">
+  <meta itemprop="description" content="Dai statistics live from the Ethereum blockchain.">
+  <meta itemprop="image" content="https://daistats.com/dai.png">
+
+  <!-- Facebook Meta Tags -->
+  <meta property="og:url" content="https://daistats.com">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Dai Stats">
+  <meta property="og:description" content="Dai statistics live from the Ethereum blockchain.">
+  <meta property="og:image" content="https://daistats.com/dai.png">
+
+  <!-- Twitter Meta Tags -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Dai Stats">
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:creator" content="@nanexcool" />
   <meta name="twitter:site" content="@nanexcool" />
-  <meta name="twitter:title" content="Dai Stats" />
-  <meta name="twitter:description" content="Dai numbers at a glance" />
-  <meta name="twitter:image" content="https://daistats.com/dai.svg" />
-  <title>Dai Stats</title>
+  <meta name="twitter:description" content="Dai numbers at a glance">
+  <meta name="twitter:image" content="https://daistats.com/dai.png">
+
   <!-- Start Single Page Apps for GitHub Pages -->
   <script type="text/javascript">
     // Single Page Apps for GitHub Pages

--- a/public/index.html
+++ b/public/index.html
@@ -27,7 +27,6 @@
   <!-- Twitter Meta Tags -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Dai Stats">
-  <meta name="twitter:card" content="summary" />
   <meta name="twitter:creator" content="@nanexcool" />
   <meta name="twitter:site" content="@nanexcool" />
   <meta name="twitter:description" content="Dai numbers at a glance">


### PR DESCRIPTION
Updates metatags for google/twitter/facebook shares. 

Switched from `svg` to `png` since `png` is in the public folder.
