### PR TITLE
Fix smiley react warning

### DIFF
--- a/src/Main.jsx
+++ b/src/Main.jsx
@@ -265,7 +265,7 @@ const Main = (props) => {
             </div>
             <div className="column">
               <div className="box has-text-centered">
-                <h3 className="title" title={props.flapKicks}>{formatAmount.format(props.flapKicks)} 😃</h3>
+                <h3 className="title" title={props.flapKicks}>{formatAmount.format(props.flapKicks)} <span role="img" aria-label="smiley">😃</span></h3>
                 <p className="title subtitle is-size-4">Dai Surplus (Flap) Auctions</p>
                 <p className="subtitle is-size-6">Till next Flap: {formatAmount.format((Number(props.surplusBuffer) + Number(props.surplusBump) + Number(props.sysDebt) + Number(props.sin)) - Number(props.sysSurplus))}</p>
               </div>


### PR DESCRIPTION
Fixes react warning:

```
./src/Main.jsx
  Line 268:17:  Emojis should be wrapped in <span>, have role="img", and have an accessible description with aria-label or aria-labelledby  jsx-a11y/accessible-emoji
```