### PR TITLE
Build action

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,39 @@
+name: GitHub Pages Deployment
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v2.1.0
+        with:
+          node-version: '12.x'
+
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - run: yarn install --frozen-lockfile
+
+      # Build with CI=false to avoid treating lint warnings as errors.
+      - run: CI=false yarn build
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          publish_dir: ./build

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -36,4 +36,5 @@ jobs:
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           publish_dir: ./build

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -30,11 +30,26 @@ jobs:
 
       - run: yarn install --frozen-lockfile
 
+      # Patch 
+      - name: Patch homepage value
+        run: |-
+          if [[ ! -z "${{ secrets.HOMEPAGE }}" ]]; then
+            cp package.json{,.bak}
+            jq -s '.[0] * .[1]' -- package.json.bak - <<- FOE > package.json
+              {
+                "homepage": "${{ secrets.HOMEPAGE }}"
+              }
+          FOE
+            cat package.json
+          fi
+
       # Build with CI=false to avoid treating lint warnings as errors.
       - run: CI=false yarn build
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
+          # Set ACTIONS_DEPLOY_KEY to deploy
+          # See https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-create-ssh-deploy-key on how to set this up.
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           publish_dir: ./build


### PR DESCRIPTION
Hey, so I was trying to figure out the discrepancy between daistats' ETH price and daiauctions' ETH price, and before I noticed that daistats goes by the OSM value, whereas daiauctions uses the current medianizer value, I managed to automate the website's deployment. 

With this GitHub workflow, deploying daistats is as easy as merging into master. To use it, you'll need to set up to bits:
1. Add a deployment key & secret, see https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-create-ssh-deploy-key on how to do that.
2. (Optional for daistats.com) Add `HOMEPAGE` [secret](https://github.com/freeatnet/daistats/settings/secrets) to set the domain / path to build the React app for (e.g., if you want to deploy a version to nanexcool.github.io/other-daistats`).

